### PR TITLE
HSDO-19 | Main menu dropdown toggle.

### DIFF
--- a/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
+++ b/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
@@ -38,10 +38,10 @@ function stanford_jsa_layouts_menu_block_blocks() {
       'menu_name'   => 'main-menu',
       'parent_mlid' => 0,
       'title_link'  => 0,
-      'admin_title' => 'Main Menu - Primary - 2+ Depth',
+      'admin_title' => 'Main Menu - Primary - 2 Depth',
       'level'       => 1,
       'follow'      => 0,
-      'depth'       => 0,
+      'depth'       => 2,
       'expanded'    => 1,
       'sort'        => 0,
     ),
@@ -120,7 +120,7 @@ function stanford_jsa_layouts_form_menu_overview_form_alter_submit($form, &$form
     variable_set("stanford_jsa_layouts_sitewide_context", $copy->name);
   }
 
-  // Load the active context.
+  // Load the active context. Could be either the clone or the original.
   $context = context_load($context_name);
 
   // If dropdowns enabled and the 1 level block is in place replace it with the
@@ -137,7 +137,8 @@ function stanford_jsa_layouts_form_menu_overview_form_alter_submit($form, &$form
     drupal_set_message("Drop down menu block has been enabled.", "status");
   }
 
-  // If single level block ensure that the single level menu_block is in place.
+  // If single level block setting is chosen ensure that the single level
+  // menu_block is in place no matter which context it is.
   if (!$drops && !isset($context->reactions['block']['blocks']['stanford_jsa_layouts-2'])) {
     unset($context->reactions['block']['blocks']['stanford_jsa_layouts-3']);
     $context->reactions['block']['blocks']['stanford_jsa_layouts-2'] = array(

--- a/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
+++ b/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
@@ -47,3 +47,134 @@ function stanford_jsa_layouts_menu_block_blocks() {
     ),
   );
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function stanford_jsa_layouts_form_menu_overview_form_alter(&$form, &$form_state, $form_id) {
+
+  // variable_set("stanford_jsa_layouts_sitewide_context", "sitewide_jsa");
+  $sitewide_context_exists = stanford_jsa_layouts_sitewide_exists();
+  if (!$sitewide_context_exists) {
+    return;
+  }
+
+  $form["jsa"] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Dropdown Settings'),
+    '#weight' => -999,
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+
+  $form["jsa"]["stanford_jsa_layouts_dropdowns"] = array(
+    '#type' => 'radios',
+    '#title' => t('Enable drop down menu'),
+    '#default_value' => variable_get("stanford_jsa_layouts_dropdowns", 0),
+    '#options' => array(
+      0 => t('Single level menu'),
+      1 => t('Multiple level drop down menu')
+    ),
+  );
+
+  $form["#submit"][] = "stanford_jsa_layouts_form_menu_overview_form_alter_submit";
+
+}
+
+/**
+ * stanford_jsa_layouts_form_menu_overview_form_alter submit function.
+ * @param  [type] $form        [description]
+ * @param  [type] &$form_state [description]
+ * @return [type]              [description]
+ */
+function stanford_jsa_layouts_form_menu_overview_form_alter_submit($form, &$form_state) {
+  $values = $form_state["values"]["jsa"];
+  $drops = check_plain($values["stanford_jsa_layouts_dropdowns"]);
+
+  // Save the drop down settings.
+  variable_set("stanford_jsa_layouts_dropdowns", $drops);
+
+  // Do the context block swapping. In order to not override the feature we will
+  // need to clone and disable the context in the feature.
+  $context_name = variable_get("stanford_jsa_layouts_sitewide_context", "sitewide_jsa");
+
+  // If dropdowns are enabled and sitewide_jsa is the context, we will need to
+  // clone and disable.
+  if ($drops && $context_name == "sitewide_jsa") {
+
+    // Disable.
+    $context_status = variable_get("context_status", array());
+    $context_status['sitewide_jsa'] = TRUE;
+    variable_set("context_status", $context_status);
+
+    // Clone.
+    $copy = context_load("sitewide_jsa");
+    $copy->disabled = FALSE;
+    $copy->name = "sitewide_jsa_clone";
+    $copy->description = t("Sitewide - All pages - Clone");
+    unset($copy->export_module);
+    unset($copy->export_type);
+    unset($copy->in_code_only);
+    context_save($copy);
+    $context_name = $copy->name;
+    variable_set("stanford_jsa_layouts_sitewide_context", $copy->name);
+  }
+
+  // Load the active context.
+  $context = context_load($context_name);
+
+  // If dropdowns enabled and the 1 level block is in place replace it with the
+  // mulitple level block.
+  if ($drops && isset($context->reactions['block']['blocks']['stanford_jsa_layouts-2'])) {
+    unset($context->reactions['block']['blocks']['stanford_jsa_layouts-2']);
+    $context->reactions['block']['blocks']['stanford_jsa_layouts-3'] = array(
+      'module' => 'menu_block',
+      'delta' => "stanford_jsa_layouts-3",
+      'region' => 'navigation',
+      'weight' => -10,
+    );
+    context_save($context);
+    drupal_set_message("Drop down menu block has been enabled.", "status");
+  }
+
+  // If single level block ensure that the single level menu_block is in place.
+  if (!$drops && !isset($context->reactions['block']['blocks']['stanford_jsa_layouts-2'])) {
+    unset($context->reactions['block']['blocks']['stanford_jsa_layouts-3']);
+    $context->reactions['block']['blocks']['stanford_jsa_layouts-2'] = array(
+      'module' => 'menu_block',
+      'delta' => "stanford_jsa_layouts-2",
+      'region' => 'navigation',
+      'weight' => -10,
+    );
+    context_save($context);
+    drupal_set_message("Drop down menu block has been disabled.", "status");
+  }
+
+}
+
+/**
+ * Checks to see if the sitewide_jsa, or clone, context exists and is enabled.
+ *
+ * @return bool
+ *   Returns true if all conditions are met. False if not.
+ */
+function stanford_jsa_layouts_sitewide_exists() {
+
+  $context_name = variable_get("stanford_jsa_layouts_sitewide_context", "sitewide_jsa");
+
+  // Load the sitewide context.
+  $context = context_load($context_name);
+
+  // No context. No menu switchy.
+  if (!$context) {
+    return FALSE;
+  }
+
+  // Check to see if enabled. If not, no menu switchy.
+  if ($context->disabled) {
+    return FALSE;
+  }
+
+  // We is good.
+  return TRUE;
+}

--- a/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
+++ b/modules/stanford_jsa_layouts/stanford_jsa_layouts.module
@@ -34,5 +34,16 @@ function stanford_jsa_layouts_menu_block_blocks() {
       'expanded'    => 1,
       'sort'        => 0,
     ),
+    'stanford_jsa_layouts-3' => array(
+      'menu_name'   => 'main-menu',
+      'parent_mlid' => 0,
+      'title_link'  => 0,
+      'admin_title' => 'Main Menu - Primary - 2+ Depth',
+      'level'       => 1,
+      'follow'      => 0,
+      'depth'       => 0,
+      'expanded'    => 1,
+      'sort'        => 0,
+    ),
   );
 }


### PR DESCRIPTION
# Ready for review

**To test:**
1. Either on an existing site or a new jsa build check out this branch
2. Clear all caches
3. Navigate to 'admin/structure/menu/manage/main-menu'

At the bottom of that page you should find a dropdown settings fieldset if the `sitewide_jsa` context is available. 
1. Toggle the setting to 'Multiple level drop down menu' and save the form.
2. You should have a message letting you know drop downs have been enabled.
3. Navigate to the context page: 'admin/structure/context'
4. There should now be a copy of sitewide_jsa called sitewide_jsa_clone and the original should be disabled.
5. Edit the clone context and validate that 'Main Menu - Primary - 2 Depth' is the only block in the Navigation region.
6. Navigate to the home page and validate that the Drop down menu is toggling as a drop down.
7. Navigate back to 'admin/structure/menu/manage/main-menu' and set the drop down setting to 'Single level menu'
8. Navigate to the context page 'admin/structure/context'
9. Validate that the sitewide_jsa_clone context is enabled and the original is disabled.
10. Navigate to the home page and validate that the menu is back to one level.
