### PR TITLE
HSDO-741 Hide Preview Buttons by default

### DIFF
--- a/stanford_jumpstart_academic.install
+++ b/stanford_jumpstart_academic.install
@@ -27,3 +27,13 @@ function stanford_jumpstart_academic_disable() {
  */
 function stanford_jumpstart_academic_uninstall() {
 }
+
+/**
+ * Disable the preview button on node types.
+ */
+function stanford_jumpstart_academic_update_7100() {
+  $types = node_type_get_types();
+  foreach (array_keys($types) as $type) {
+    variable_set("node_preview_$type", 0);
+  }
+}

--- a/stanford_jumpstart_academic.module
+++ b/stanford_jumpstart_academic.module
@@ -18,3 +18,12 @@ function stanford_jumpstart_academic_help($path, $arg) {
       return '<p>' . t('Needs Work %email', array('%email' => l('SWS','mailto:sitesjumpstart-help@lists.stanford.edu'))) . '</p>';
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_jumpstart_academic_form_node_type_form_alter(&$form, &$form_state, $form_id) {
+  if (empty($form['#node_type']->type)) {
+    $form['submission']['node_preview']['#default_value'] = 0;
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- By default disable the preview button on node edit pages

# Needed By (Date)
- 4/12

# Steps to Test

1. Checkout the branch
2. run db updates & clear cache
3. check various nodes to ensure the preview button is gone.
4. go to create a new content type and check that the preview button default setting is 'disabled'