### PR TITLE
HSDO-29 Added site owner to view reports pages

### DIFF
--- a/modules/stanford_jsa_roles/stanford_jsa_roles.features.user_permission.inc
+++ b/modules/stanford_jsa_roles/stanford_jsa_roles.features.user_permission.inc
@@ -90,6 +90,16 @@ function stanford_jsa_roles_user_default_permissions() {
     'module' => 'system',
   );
 
+  // Exported permission: 'access site reports'.
+  $permissions['access site reports'] = array(
+    'name' => 'access site reports',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'site owner' => 'site owner',
+    ),
+    'module' => 'system',
+  );
+
   // Exported permission: 'access user profiles'.
   $permissions['access user profiles'] = array(
     'name' => 'access user profiles',

--- a/modules/stanford_jsa_roles/stanford_jsa_roles.info
+++ b/modules/stanford_jsa_roles/stanford_jsa_roles.info
@@ -45,6 +45,7 @@ features[user_permission][] = access contextual links
 features[user_permission][] = access jumpstart features
 features[user_permission][] = access jumpstart help
 features[user_permission][] = access site in maintenance mode
+features[user_permission][] = access site reports
 features[user_permission][] = access user profiles
 features[user_permission][] = administer bean settings
 features[user_permission][] = administer bean types


### PR DESCRIPTION
# Not READY FOR REVIEW

# Summary
- Added site owner to view reports pages

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test

1. Checkout branch
2. revert feature `drush fr stanford_jsa_roles -y`
3. validate site owner can view the 404 reports page.

# Related
https://github.com/SU-SWS/stanford_jumpstart/pull/78