### PR TITLE
SITES-761 Added events calendar context back

### DIFF
--- a/modules/stanford_jsa_layouts/stanford_jsa_layouts.context.inc
+++ b/modules/stanford_jsa_layouts/stanford_jsa_layouts.context.inc
@@ -297,7 +297,18 @@ function stanford_jsa_layouts_context_default_contexts() {
       ),
     ),
   );
-  $context->reactions = array();
+  $context->reactions = array(
+    'block' => array(
+      'blocks' => array(
+        'views-934c9b9d8d2d2f2b37f050dcd3bba83c' => array(
+          'module' => 'views',
+          'delta' => '934c9b9d8d2d2f2b37f050dcd3bba83c',
+          'region' => 'sidebar_second',
+          'weight' => '-10',
+        ),
+      ),
+    ),
+  );
   $context->condition_mode = 0;
 
   // Translatables


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- It appears in 7.x-3.x there was a reaction on this context to place a calendar block on the event nodes.
Option 1. merge this
Option 2. clone the context on the current live site, and delete this context from code.

# Needed By (Date)
- 🤷‍♂️ 

# Urgency
- low

# Steps to Test

1. review

# Affected Projects or Products
- https://classics.stanford.edu/events/nevertheless-they-persisted-euripides-hecubahelen-7

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)