### PR TITLE
SITES-778 Set missing help text variables

### DIFF
--- a/help-text/stanford_jumpstart_help_pages_features.html
+++ b/help-text/stanford_jumpstart_help_pages_features.html
@@ -1,0 +1,25 @@
+<p>Features are a great way to enhance the functionality of your site. Because Drupal is a fully extensible content management system, you can easily extend the functionality of your site. In the list below you can choose from the standard features offered by Stanford Web Services. Additional features and functionality are available upon request.</p>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="border:none;">
+  <tbody><tr>
+    <td><h2>Add Blocks or Change Block Layouts</h2>
+      <p>By default, your site includes several blocks located on the homage and footer (for example). You can request additional blocks for subpage sidebars or landing pages and also request alternate block layouts as seen on the <a href="https://sites.stanford.edu/jumpstart-demo2/" target="_blank">Jumpstart layouts demo pages</a>. When requesting a new block, let us know exactly on which page(s) the block will be displayed (include URLs). If you'd like an alternate block layout, contact us and tell us <a href="https://sites.stanford.edu/jumpstart-demo2/" target="_blank">which layout</a> you would like.</p>
+    </td>
+    <td><p><a href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_1EK9guIGepRtvwh&amp;Name=admin&amp;Email=sws-developers@lists.stanford.edu&amp;URL=http://jsa.jumpstart.loc/&amp;Feature=Add%20Blocks%20or%20Change%20Block%20Layouts" class="btn btn-request" target="blank">Request This Feature</a></p></td>
+  </tr>
+  <tr>
+    <td><h2>In-Development Site Protection</h2>
+      <p>By default, your site is hidden from search engines while you are in development, but anyone you send the URL to can access the site. If you have sensitive content that you want to protect under WebAuth  while you are developing your site, then request this feature.</p>
+    </td>
+    <td width="150"><p><a href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_1EK9guIGepRtvwh&amp;Name=admin&amp;Email=sws-developers@lists.stanford.edu&amp;URL=http://jsa.jumpstart.loc/&amp;Feature=In-Development%20Site%20Protection" class="btn btn-request" target="blank">Request This Feature</a></p></td>
+  </tr>
+  <tr><td><h2>Display an External RSS Feed</h2>
+    <p>Want to display items from a single, external RSS feed or aggregate many feeds into a list on your website? We can generate a block and a full page listing of the most recent items. We can work with you to add this dynamic content to your website. When submitting your request, include links to the RSS feed(s) you want to pull in to your site.</p>
+  </td>
+    <td><p><a href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_1EK9guIGepRtvwh&amp;Name=admin&amp;Email=sws-developers@lists.stanford.edu&amp;URL=http://jsa.jumpstart.loc/&amp;Feature=Display%20an%20External%20RSS%20Feed" class="btn btn-request" target="blank">Request This Feature</a></p></td>
+  </tr>
+  </tbody></table>
+<div class="block-extrainfo-full">
+  <h2>Request Full Admin Access</h2>
+  <p>If you are experienced in using Drupal's full administrative options and want the power to enable modules, create Views, and more, you can contact Stanford Web Services to request full administrative access. Having full administrative access means that you can more easily break your site, so we will want to make sure that you have sufficient Drupal knowledge and hear more about your specific goals before enabling this permission. </p>
+  <p><a href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_1EK9guIGepRtvwh&amp;Name=admin&amp;Email=sws-developers@lists.stanford.edu&amp;URL=http://jsa.jumpstart.loc/&amp;Feature=Full%20Administrative%20Access" class="btn btn-request" target="blank">Request Full Admin Access</a></p>
+</div>

--- a/help-text/stanford_jumpstart_help_pages_help.html
+++ b/help-text/stanford_jumpstart_help_pages_help.html
@@ -1,0 +1,44 @@
+<div class="block-extrainfo block-need-assistance">
+  <h2>Need assistance with your site?</h2>
+  <p>Submit a help form to Stanford Web Services to request personal assistance with your site.</p>
+  <p><a href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_1EK9guIGepRtvwh&amp;Name=admin&amp;Email=sws-developers@lists.stanford.edu&amp;URL=http://jsa.jumpstart.loc/" class="btn btn-request" target="blank">Request Assistance</a></p>
+</div>
+
+<h2>Jumpstart User Guide</h2>
+<p>Do you need help with Stanford Sites Jumpstart? Look no further! We have lots of helpful tips in our user guide. The following pages might get you started:</p>
+<ul>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/getting-started-your-new-site" target="_blank">Your new site</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/menus" target="_blank">Menus</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/pages" target="_blank">Pages</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/blocks" target="_blank">Blocks</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/content-editor" target="_blank">Content editor</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/multimedia" target="_blank">Multimedia</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/design" target="_blank">Design</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/users" target="_blank">Users</a></li>
+  <li><a href="https://sites-jumpstart.stanford.edu/user-guide/premium-features" target="_blank">Premium Features</a> (including: news, events, profiles, publications, manage content, manage taxonomy, footer menu)</li>
+</ul>
+<p><a class="btn btn-request" href="https://sites-jumpstart.stanford.edu/user-guide/overview">View user guide</a></p>
+
+<h2>Drupal resources at Stanford</h2>
+<p>Stanford has a very active and engaged Drupal community, and many centrally offered and community created resources that might help you.</p>
+<ul>
+  <li><a href="https://itservices.stanford.edu/service/techtraining/schedule" target="_blank">IT Services Technology Training</a><br>
+    Check the upcoming courses schedule for Drupal-specific training courses offered to Stanford faculty and staff.  </li>
+  <li><a href="http://itservices.stanford.edu/service/web/stanfordsites/userguide" target="_blank">Stanford Sites User Guide</a><br>
+    Your site is hosted on the Stanford Sites platform.
+    The Sites User Guide provides general information about using the service as well as how to videos for common Drupal tasks.</li>
+  <li><a href="http://swsblog.stanford.edu" target="_blank">Stanford Web Services Blog</a><br>
+    The Stanford Web Services team blogs about all things related to Stanford Sites, Drupal, design, site building, and many other topics. This is a great resource for SWS clients.</li>
+  <li><a href="https://opensource.stanford.edu/knowledge?field_topics_tid=6" target="_blank">Tech Commons</a><br>
+    Tech Commons is a community-created resource for technical knowledge. There is a section for Drupal with many helpful tutorials, discussions, and information.</li>
+  <li><a href="https://learndrupal.stanford.edu/" target="_blank">Learn Drupal</a><br>
+    A clearinghouse for community voted best Drupal learning resources.
+  </li>
+  <li><a href="https://opensource.stanford.edu/events" target="_blank">Mornings o' Code,  Drupallers Drop-in Help, Drupallers Co-Working Sessions</a><br>
+    Stanford Drupallers (new and and experienced) meet regularly to help troubleshoot each others' problems. Check the schedule for upcoming co-working sessions</li>
+</ul>
+<h2>Connect with the Drupal Community</h2>
+<p>The main way the Stanford Drupal community communicates is through the Drupallers Mailing List. You can join this list to participate in the community discussion. Feel free to post questions to the list, or post responses to help others.</p>
+<ul>
+  <li><a href="https://mailman.stanford.edu/mailman/listinfo/drupallers" target="_blank">Join the Drupallers Mailing List</a></li>
+</ul>

--- a/help-text/stanford_jumpstart_help_pages_launch.html
+++ b/help-text/stanford_jumpstart_help_pages_launch.html
@@ -1,0 +1,94 @@
+<h2>Launch Checklist</h2>
+<table border="0" cellpadding="0" cellspacing="0" style="border:none;" width="100%">
+  <tbody>
+  <tr>
+    <td>
+      <h3>Content Cleanup</h3>
+      <ul>
+        <li>Have you renamed or removed any starter pages that aren’t relevant to your site?</li>
+        <li>Has all placeholder text in starter pages been replaced?</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Blocks</h3>
+      <ul>
+        <li>Have you hidden the Blocks that aren’t relevant to your site?</li>
+        <li>Do your homepage and footer Blocks have the correct content in them?</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Images</h3>
+      <ul>
+        <li>Are all placeholder images relevant to your site or have they been replaced?</li>
+        <li>Do all images have short descriptive alternate text for accessibility?</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Links</h3>
+      <ul>
+        <li>Are all “Read More” text set as links and the links within content correct?</li>
+        <li>Are all of your menu links correct?</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>URL Redirects</h3>
+      <ul>
+        <li>If you have an existing website, it’s likely that users have bookmarked specific pages. Inventory the most important pages from your old website; Stanford Web Services will build redirects, so that those old bookmarks will still work after launch. Here is an <a href="https://stanford.box.com/s/h85hy9rgqhfaks2no07m" target="_blank">Example Spreadsheet</a>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Vanity URL</h3>
+      <ul>
+        <li>Do you already have a Vanity URL (e.g. https://<em>mysite</em>.stanford.edu)? Stanford Web Services will handle the switchover for you, just tell us what it is.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Google Analytics</h3>
+      <ul>
+        <li>Do you have a existing Google Analytics account? Please provide us with the&nbsp;Web Property ID&nbsp;(e.g., UA-1234567-8). If not, Stanford Web Services can request one and set that up for you.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Existing Website</h3>
+      <ul style="letter-spacing: 0.16px; line-height: 22.4px;">
+        <li>Do you have a existing website? If yes,&nbsp;consider what to do with the old site.</li>
+        <li>Do you need to access the old site after launch?&nbsp;You might consider setting up a <a href="http://web.stanford.edu/dept/as/mais/applications/workgroup/">Workgroup</a> to control user access permissions, or looking into <a href="https://library.stanford.edu/projects/web-archiving/archivability">archiving the site within Stanford Libraries</a>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h3>Approval</h3>
+      <ul>
+        <li>Does your site need to be approved by anyone other than you before launching?</li>
+      </ul>
+    </td>
+  </tr>
+  </tbody>
+</table>
+<div class="block-extrainfo-full">
+  <h2>Are you ready to launch your site?</h2>
+  <p>Launching your site means:</p>
+  <ul>
+    <li>It will be assigned a Vanity URL (such as http://mysite.stanford.edu)</li>
+    <li>It will be made available to search engines</li>
+    <li>You can still request an additional consultation with Stanford Web Services for a content and design review</li>
+  </ul>
+  <p>Once you have gone through the launch checklist above, you can request to launch your site.&nbsp;Stanford Web Services requests at least two weeks' advanced notice. Launches are scheduled Tuesdays through Thursdays. During peak periods, some dates may not be available; date flexibility is appreciated!</p>
+  <p>Congratulations! This may sound scary, but you have a team behind you to make sure that launch goes as smoothly as possible.</p>
+  <p><a class="btn btn-request" href="https://stanforduniversity.qualtrics.com/SE/?SID=SV_01I4MJkFACIhhIN" target="_blank">Schedule Site Launch</a></p>
+</div>

--- a/stanford_jumpstart_academic.install
+++ b/stanford_jumpstart_academic.install
@@ -10,3 +10,20 @@
 function stanford_jumpstart_academic_update_7100() {
   // Removed.
 }
+
+/**
+ * Set any missing variables.
+ */
+function stanford_jumpstart_academic_update_7600(){
+  $variables = [
+    'stanford_jumpstart_help_pages_help',
+    'stanford_jumpstart_help_pages_features',
+    'stanford_jumpstart_help_pages_launch',
+  ];
+  foreach ($variables as $variable) {
+    if (variable_get($variable)) {
+      $help_text = file_get_contents(drupal_get_path('module', 'stanford_jumpstart_academic') . "/help-text/$variable.html");
+      variable_set($variable, array('content' => array('#markup' => $help_text)));
+    }
+  }
+}

--- a/stanford_jumpstart_academic.install
+++ b/stanford_jumpstart_academic.install
@@ -21,7 +21,7 @@ function stanford_jumpstart_academic_update_7600(){
     'stanford_jumpstart_help_pages_launch',
   ];
   foreach ($variables as $variable) {
-    if (variable_get($variable)) {
+    if (empty(variable_get($variable))) {
       $help_text = file_get_contents(drupal_get_path('module', 'stanford_jumpstart_academic') . "/help-text/$variable.html");
       variable_set($variable, array('content' => array('#markup' => $help_text)));
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When stanford_jumpstart is updated the help text is lost. This sets the missing variables to the values that are set by the install tasks.

# Needed By (Date)
- asap

# Urgency
- medium

# Steps to Test

1. Use this branch and migrate buddhiststudies site
1. verify jumpstart help pages a

# Affected Projects or Products
- JSA
- This might help others if there are similar issues.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)