### PR TITLE
HSD8-925: Added 4 JSA feature exporter modules

### DIFF
--- a/modules/stanford_jsa_d8_exporter_events/CHANGELOG.txt
+++ b/modules/stanford_jsa_d8_exporter_events/CHANGELOG.txt
@@ -1,0 +1,4 @@
+Stanford Events Export x.x-x.x, xxxx-xx-xx
+------------------------------------------
+
+Initial Release 2014-03-11

--- a/modules/stanford_jsa_d8_exporter_events/CHANGELOG.txt
+++ b/modules/stanford_jsa_d8_exporter_events/CHANGELOG.txt
@@ -1,4 +1,0 @@
-Stanford Events Export x.x-x.x, xxxx-xx-xx
-------------------------------------------
-
-Initial Release 2014-03-11

--- a/modules/stanford_jsa_d8_exporter_events/README.md
+++ b/modules/stanford_jsa_d8_exporter_events/README.md
@@ -1,0 +1,7 @@
+-- SUMMARY --
+Author: John Bickar
+
+The Stanford Events Export module contains Views that expose Stanford Event
+content as JSON and XML data. Useful in combination with the Stanford Drupal
+Events Importer module to migrate Stanford Event content from one Drupal site
+to another.

--- a/modules/stanford_jsa_d8_exporter_events/README.md
+++ b/modules/stanford_jsa_d8_exporter_events/README.md
@@ -1,7 +1,3 @@
--- SUMMARY --
-Author: John Bickar
-
-The Stanford Events Export module contains Views that expose Stanford Event
-content as JSON and XML data. Useful in combination with the Stanford Drupal
-Events Importer module to migrate Stanford Event content from one Drupal site
-to another.
+Stanford JSA D8 Events Exporter
+---
+This module provides views for exporting events data. Based off of stanford_events_export

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.features.inc
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.features.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_events.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function stanford_jsa_d8_exporter_events_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "strongarm" && $api == "strongarm") {
+    return array("version" => "1");
+  }
+}
+
+/**
+ * Implements hook_views_api().
+ */
+function stanford_jsa_d8_exporter_events_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.info
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.info
@@ -1,5 +1,5 @@
-name = Stanford Sites Jumpstart Academic D8 Publications Exporter
-description = Provides views for exporting publications data. Based off of stanford_events_export
+name = Stanford Sites Jumpstart Academic D8 Events Exporter
+description = Provides views for exporting events data. Based off of stanford_events_export
 core = 7.x
 package = Stanford Sites Jumpstart Academic
 version = 7.x-6.1-dev

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.info
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.info
@@ -1,0 +1,16 @@
+name = Stanford Sites Jumpstart Academic D8 Publications Exporter
+description = Provides views for exporting publications data. Based off of stanford_events_export
+core = 7.x
+package = Stanford Sites Jumpstart Academic
+version = 7.x-6.1-dev
+hidden = TRUE
+dependencies[] = strongarm
+dependencies[] = views_data_export
+dependencies[] = views_json
+dependencies[] = views_xhtml
+features[ctools][] = strongarm:strongarm:1
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[variable][] = date_format_iso_8601
+features[views_view][] = stanford_jsa_d8_exporter_events
+features_exclude[dependencies][views] = views

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.module
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the Stanford Events Export feature.
+ */
+
+include_once 'stanford_jsa_d8_exporter_events.features.inc';

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.strongarm.inc
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.strongarm.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_events.strongarm.inc
+ */
+
+/**
+ * Implements hook_strongarm().
+ */
+function stanford_jsa_d8_exporter_events_strongarm() {
+  $export = array();
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'date_format_iso_8601';
+  $strongarm->value = 'c';
+  $export['date_format_iso_8601'] = $strongarm;
+
+  return $export;
+}

--- a/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_events/stanford_jsa_d8_exporter_events.views_default.inc
@@ -1,0 +1,365 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_events.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function stanford_jsa_d8_exporter_events_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'stanford_jsa_d8_exporter_events';
+  $view->description = 'List-style page and sidebar block';
+  $view->tag = '';
+  $view->base_table = 'node';
+  $view->human_name = 'Stanford Events Export';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Events';
+  $handler->display->display_options['use_more'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '0';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2] ';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  /* Field: Content: Image */
+  $handler->display->display_options['fields']['field_stanford_event_image']['id'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['table'] = 'field_data_field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['field'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['label'] = '';
+  $handler->display->display_options['fields']['field_stanford_event_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_stanford_event_image']['settings'] = array(
+    'image_style' => '',
+    'image_link' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['id'] = 'field_stanford_event_datetime_2';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['label'] = 'Date and Time (Start)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2]';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['id'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['label'] = 'Date and Time (End)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value2',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Add to Calendar */
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['id'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['table'] = 'field_data_field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['field'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['click_sort_column'] = 'url';
+  /* Field: Content: Location */
+  $handler->display->display_options['fields']['field_stanford_event_location']['id'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['table'] = 'field_data_field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['field'] = 'field_stanford_event_location';
+  /* Field: Content: Event Sponsor */
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['id'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['table'] = 'field_data_field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['field'] = 'field_stanford_event_sponsor';
+  /* Field: Content: Contact Email */
+  $handler->display->display_options['fields']['field_stanford_event_email']['id'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['table'] = 'field_data_field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['field'] = 'field_stanford_event_email';
+  /* Field: Content: Contact Phone */
+  $handler->display->display_options['fields']['field_stanford_event_phone']['id'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['table'] = 'field_data_field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['field'] = 'field_stanford_event_phone';
+  /* Field: Content: Admission */
+  $handler->display->display_options['fields']['field_stanford_event_admission']['id'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['table'] = 'field_data_field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['field'] = 'field_stanford_event_admission';
+  /* Field: Content: More Information */
+  $handler->display->display_options['fields']['field_stanford_event_url']['id'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['table'] = 'field_data_field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['field'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['click_sort_column'] = 'url';
+  /* Field: Content: Audience */
+  $handler->display->display_options['fields']['field_stanford_event_audience']['id'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['table'] = 'field_data_field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['field'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['delta_offset'] = '0';
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_stanford_event_categories']['id'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['table'] = 'field_data_field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['field'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['delta_offset'] = '0';
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_event' => 'stanford_event',
+  );
+
+  /* Display: Events Data w/ series export */
+  $handler = $view->new_display('views_data_export', 'Events Data w/ series export', 'views_data_export_1');
+  $handler->display->display_options['defaults']['link_display'] = FALSE;
+  $handler->display->display_options['defaults']['query'] = FALSE;
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_xml';
+  $handler->display->display_options['style_options']['provide_file'] = 0;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['transform'] = 1;
+  $handler->display->display_options['style_options']['root_node'] = 'EventList';
+  $handler->display->display_options['style_options']['item_node'] = 'Event';
+  $handler->display->display_options['style_options']['cdata_wrapper'] = array(
+    'body' => 'body',
+    'body_1' => 'body_1',
+  );
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Content: Image (field_stanford_event_image:fid) */
+  $handler->display->display_options['relationships']['field_stanford_event_image_fid']['id'] = 'field_stanford_event_image_fid';
+  $handler->display->display_options['relationships']['field_stanford_event_image_fid']['table'] = 'field_data_field_stanford_event_image';
+  $handler->display->display_options['relationships']['field_stanford_event_image_fid']['field'] = 'field_stanford_event_image_fid';
+  /* Relationship: Entity Reference: Referenced Entity */
+  $handler->display->display_options['relationships']['field_s_event_series_target_id']['id'] = 'field_s_event_series_target_id';
+  $handler->display->display_options['relationships']['field_s_event_series_target_id']['table'] = 'field_data_field_s_event_series';
+  $handler->display->display_options['relationships']['field_s_event_series_target_id']['field'] = 'field_s_event_series_target_id';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid']['id'] = 'uuid';
+  $handler->display->display_options['fields']['uuid']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid']['label'] = 'eventID';
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid_1']['id'] = 'uuid_1';
+  $handler->display->display_options['fields']['uuid_1']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid_1']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid_1']['label'] = 'guid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['id'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['label'] = 'isoEventDate';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['alter']['text'] = '[field_stanford_event_datetime-value] +0000';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['type'] = 'date_plain';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y-m-d H:i:s',
+    'fromto' => 'value',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['id'] = 'field_stanford_event_datetime_1';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['label'] = 'isoEventEndDate';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['alter']['text'] = '[field_stanford_event_datetime_1-value2] +0000';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['type'] = 'date_plain';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_1']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y-m-d H:i:s',
+    'fromto' => 'value2',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: More Information */
+  $handler->display->display_options['fields']['field_stanford_event_url']['id'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['table'] = 'field_data_field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['field'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['label'] = 'link';
+  $handler->display->display_options['fields']['field_stanford_event_url']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['type'] = 'link_plain';
+  $handler->display->display_options['fields']['field_stanford_event_url']['settings'] = array(
+    'custom_title' => '',
+  );
+  $handler->display->display_options['fields']['field_stanford_event_url']['delta_offset'] = '0';
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  $handler->display->display_options['fields']['body']['label'] = 'description';
+  /* Field: Content: Admission */
+  $handler->display->display_options['fields']['field_stanford_event_admission']['id'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['table'] = 'field_data_field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['field'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['label'] = 'admissionDescription';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['alter']['strip_tags'] = TRUE;
+  /* Field: Content: Map Link */
+  $handler->display->display_options['fields']['field_s_event_map_link']['id'] = 'field_s_event_map_link';
+  $handler->display->display_options['fields']['field_s_event_map_link']['table'] = 'field_data_field_s_event_map_link';
+  $handler->display->display_options['fields']['field_s_event_map_link']['field'] = 'field_s_event_map_link';
+  $handler->display->display_options['fields']['field_s_event_map_link']['label'] = 'mapUrl';
+  $handler->display->display_options['fields']['field_s_event_map_link']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_event_map_link']['type'] = 'link_plain';
+  $handler->display->display_options['fields']['field_s_event_map_link']['settings'] = array(
+    'custom_title' => '',
+  );
+  /* Field: Content: Location */
+  $handler->display->display_options['fields']['field_stanford_event_location']['id'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['table'] = 'field_data_field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['field'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['label'] = 'locationText';
+  /* Field: Content: Event Sponsor */
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['id'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['table'] = 'field_data_field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['field'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['label'] = 'sponsor';
+  /* Field: Content: Contact Email */
+  $handler->display->display_options['fields']['field_stanford_event_email']['id'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['table'] = 'field_data_field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['field'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['label'] = 'contactEmail';
+  /* Field: Content: Contact Phone */
+  $handler->display->display_options['fields']['field_stanford_event_phone']['id'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['table'] = 'field_data_field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['field'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['label'] = 'contactPhone';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'field_stanford_event_image_fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'imageUrl';
+  $handler->display->display_options['fields']['uri']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_stanford_event_categories']['id'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['table'] = 'field_data_field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['field'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['label'] = 'categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['delta_offset'] = '0';
+  /* Field: Content: Event Type */
+  $handler->display->display_options['fields']['field_s_event_type']['id'] = 'field_s_event_type';
+  $handler->display->display_options['fields']['field_s_event_type']['table'] = 'field_data_field_s_event_type';
+  $handler->display->display_options['fields']['field_s_event_type']['field'] = 'field_s_event_type';
+  $handler->display->display_options['fields']['field_s_event_type']['label'] = 'drupalType';
+  $handler->display->display_options['fields']['field_s_event_type']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_event_type']['delta_offset'] = '0';
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body_1']['id'] = 'body_1';
+  $handler->display->display_options['fields']['body_1']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body_1']['field'] = 'body';
+  $handler->display->display_options['fields']['body_1']['relationship'] = 'field_s_event_series_target_id';
+  $handler->display->display_options['fields']['body_1']['label'] = 'eventSeriesBody';
+  $handler->display->display_options['fields']['body_1']['type'] = 'text_plain';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title_1']['id'] = 'title_1';
+  $handler->display->display_options['fields']['title_1']['table'] = 'node';
+  $handler->display->display_options['fields']['title_1']['field'] = 'title';
+  $handler->display->display_options['fields']['title_1']['relationship'] = 'field_s_event_series_target_id';
+  $handler->display->display_options['fields']['title_1']['label'] = 'eventSeriesTitle';
+  $handler->display->display_options['fields']['title_1']['link_to_node'] = FALSE;
+  /* Field: Content: Audience */
+  $handler->display->display_options['fields']['field_stanford_event_audience']['id'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['table'] = 'field_data_field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['field'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['label'] = 'audiences';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['delta_offset'] = '0';
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_event' => 'stanford_event',
+  );
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  $handler->display->display_options['path'] = 'events-xml';
+  $export['stanford_jsa_d8_exporter_events'] = $view;
+
+  return $export;
+}

--- a/modules/stanford_jsa_d8_exporter_news/README.md
+++ b/modules/stanford_jsa_d8_exporter_news/README.md
@@ -1,0 +1,3 @@
+Stanford JSA D8 News Exporter
+---
+This module provides views for exporting news data.

--- a/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.features.inc
+++ b/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.features.inc
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_news.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function stanford_jsa_d8_exporter_news_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.info
+++ b/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.info
@@ -1,0 +1,11 @@
+name = Stanford Sites Jumpstart Academic D8 News Exporter
+description = Provides views for exporting news data
+core = 7.x
+package = Stanford Sites Jumpstart Academic
+version = 7.x-6.1-dev
+hidden = TRUE
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[views_view][] = stanford_news_export
+features_exclude[dependencies][views] = views
+features_exclude[dependencies][views_data_export] = views_data_export

--- a/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.module
+++ b/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the Stanford Sites Jumpstart Academic D8 News Exporter feature.
+ */
+
+include_once 'stanford_jsa_d8_exporter_news.features.inc';

--- a/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.views_default.inc
@@ -1,0 +1,408 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_news.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function stanford_jsa_d8_exporter_news_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'stanford_news_export';
+  $view->description = 'List-style page and sidebar block';
+  $view->tag = '';
+  $view->base_table = 'node';
+  $view->human_name = 'Stanford News Export';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Events';
+  $handler->display->display_options['use_more'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '0';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2] ';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  /* Field: Content: Image */
+  $handler->display->display_options['fields']['field_stanford_event_image']['id'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['table'] = 'field_data_field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['field'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['label'] = '';
+  $handler->display->display_options['fields']['field_stanford_event_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_stanford_event_image']['settings'] = array(
+    'image_style' => '',
+    'image_link' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['id'] = 'field_stanford_event_datetime_2';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['label'] = 'Date and Time (Start)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2]';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['id'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['label'] = 'Date and Time (End)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value2',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Add to Calendar */
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['id'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['table'] = 'field_data_field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['field'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['click_sort_column'] = 'url';
+  /* Field: Content: Location */
+  $handler->display->display_options['fields']['field_stanford_event_location']['id'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['table'] = 'field_data_field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['field'] = 'field_stanford_event_location';
+  /* Field: Content: Event Sponsor */
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['id'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['table'] = 'field_data_field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['field'] = 'field_stanford_event_sponsor';
+  /* Field: Content: Contact Email */
+  $handler->display->display_options['fields']['field_stanford_event_email']['id'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['table'] = 'field_data_field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['field'] = 'field_stanford_event_email';
+  /* Field: Content: Contact Phone */
+  $handler->display->display_options['fields']['field_stanford_event_phone']['id'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['table'] = 'field_data_field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['field'] = 'field_stanford_event_phone';
+  /* Field: Content: Admission */
+  $handler->display->display_options['fields']['field_stanford_event_admission']['id'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['table'] = 'field_data_field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['field'] = 'field_stanford_event_admission';
+  /* Field: Content: More Information */
+  $handler->display->display_options['fields']['field_stanford_event_url']['id'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['table'] = 'field_data_field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['field'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['click_sort_column'] = 'url';
+  /* Field: Content: Audience */
+  $handler->display->display_options['fields']['field_stanford_event_audience']['id'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['table'] = 'field_data_field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['field'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['delta_offset'] = '0';
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_stanford_event_categories']['id'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['table'] = 'field_data_field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['field'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['delta_offset'] = '0';
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_event' => 'stanford_event',
+  );
+
+  /* Display: News Data export */
+  $handler = $view->new_display('views_data_export', 'News Data export', 'views_data_export_1');
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_xml';
+  $handler->display->display_options['style_options']['provide_file'] = 0;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['transform'] = 1;
+  $handler->display->display_options['style_options']['root_node'] = 'NewsList';
+  $handler->display->display_options['style_options']['item_node'] = 'NewsItem';
+  $handler->display->display_options['style_options']['cdata_wrapper'] = array(
+    'body' => 'body',
+    'field_s_image_caption' => 'field_s_image_caption',
+    'field_s_image_credits' => 'field_s_image_credits',
+  );
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Field: Image (field_s_image_info) */
+  $handler->display->display_options['relationships']['field_s_image_info_value']['id'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['table'] = 'field_data_field_s_image_info';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['field'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['delta'] = '-1';
+  /* Relationship: Field collection item: Image (field_s_image_image:fid) */
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['id'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['table'] = 'field_data_field_s_image_image';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['field'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['relationship'] = 'field_s_image_info_value';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid_1']['id'] = 'uuid_1';
+  $handler->display->display_options['fields']['uuid_1']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid_1']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid_1']['label'] = 'guid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  $handler->display->display_options['fields']['body']['label'] = 'body';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'field_s_image_image_fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'image';
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  /* Field: Content: Date */
+  $handler->display->display_options['fields']['field_s_news_date']['id'] = 'field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['table'] = 'field_data_field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['field'] = 'field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['label'] = 'publishedDate';
+  $handler->display->display_options['fields']['field_s_news_date']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_s_news_date']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y-m-d',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Source */
+  $handler->display->display_options['fields']['field_s_news_source']['id'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['table'] = 'field_data_field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['field'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['label'] = 'externalLinkUrl';
+  $handler->display->display_options['fields']['field_s_news_source']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_news_source']['type'] = 'link_absolute';
+  $handler->display->display_options['fields']['field_s_news_source']['settings'] = array(
+    'custom_title' => '',
+  );
+  /* Field: Content: Source */
+  $handler->display->display_options['fields']['field_s_news_source_1']['id'] = 'field_s_news_source_1';
+  $handler->display->display_options['fields']['field_s_news_source_1']['table'] = 'field_data_field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source_1']['field'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source_1']['label'] = 'externalLinkTitle';
+  $handler->display->display_options['fields']['field_s_news_source_1']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_news_source_1']['type'] = 'link_title_plain';
+  $handler->display->display_options['fields']['field_s_news_source_1']['settings'] = array(
+    'custom_title' => '',
+  );
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_s_news_categories']['id'] = 'field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['table'] = 'field_data_field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['field'] = 'field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['label'] = 'categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_news_categories']['delta_offset'] = '0';
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_news_item' => 'stanford_news_item',
+  );
+  $handler->display->display_options['path'] = 'news-xml';
+
+  /* Display: News Data export wCaptionCredits */
+  $handler = $view->new_display('views_data_export', 'News Data export wCaptionCredits', 'views_data_export_2');
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_xml';
+  $handler->display->display_options['style_options']['provide_file'] = 0;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['transform'] = 1;
+  $handler->display->display_options['style_options']['root_node'] = 'NewsList';
+  $handler->display->display_options['style_options']['item_node'] = 'NewsItem';
+  $handler->display->display_options['style_options']['cdata_wrapper'] = array(
+    'body' => 'body',
+    'field_s_image_caption' => 'field_s_image_caption',
+  );
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Field: Image (field_s_image_info) */
+  $handler->display->display_options['relationships']['field_s_image_info_value']['id'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['table'] = 'field_data_field_s_image_info';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['field'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['delta'] = '-1';
+  /* Relationship: Field collection item: Image (field_s_image_image:fid) */
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['id'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['table'] = 'field_data_field_s_image_image';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['field'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['relationship'] = 'field_s_image_info_value';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid_1']['id'] = 'uuid_1';
+  $handler->display->display_options['fields']['uuid_1']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid_1']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid_1']['label'] = 'guid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  $handler->display->display_options['fields']['body']['label'] = 'body';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'field_s_image_image_fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'image';
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  /* Field: Content: Date */
+  $handler->display->display_options['fields']['field_s_news_date']['id'] = 'field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['table'] = 'field_data_field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['field'] = 'field_s_news_date';
+  $handler->display->display_options['fields']['field_s_news_date']['label'] = 'publishedDate';
+  $handler->display->display_options['fields']['field_s_news_date']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_s_news_date']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y-m-d',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Source */
+  $handler->display->display_options['fields']['field_s_news_source']['id'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['table'] = 'field_data_field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['field'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source']['label'] = 'externalLinkUrl';
+  $handler->display->display_options['fields']['field_s_news_source']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_news_source']['type'] = 'link_absolute';
+  $handler->display->display_options['fields']['field_s_news_source']['settings'] = array(
+    'custom_title' => '',
+  );
+  /* Field: Content: Source */
+  $handler->display->display_options['fields']['field_s_news_source_1']['id'] = 'field_s_news_source_1';
+  $handler->display->display_options['fields']['field_s_news_source_1']['table'] = 'field_data_field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source_1']['field'] = 'field_s_news_source';
+  $handler->display->display_options['fields']['field_s_news_source_1']['label'] = 'externalLinkTitle';
+  $handler->display->display_options['fields']['field_s_news_source_1']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_news_source_1']['type'] = 'link_title_plain';
+  $handler->display->display_options['fields']['field_s_news_source_1']['settings'] = array(
+    'custom_title' => '',
+  );
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_s_news_categories']['id'] = 'field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['table'] = 'field_data_field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['field'] = 'field_s_news_categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['label'] = 'categories';
+  $handler->display->display_options['fields']['field_s_news_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_news_categories']['delta_offset'] = '0';
+  /* Field: Field collection item: Caption */
+  $handler->display->display_options['fields']['field_s_image_caption']['id'] = 'field_s_image_caption';
+  $handler->display->display_options['fields']['field_s_image_caption']['table'] = 'field_data_field_s_image_caption';
+  $handler->display->display_options['fields']['field_s_image_caption']['field'] = 'field_s_image_caption';
+  $handler->display->display_options['fields']['field_s_image_caption']['relationship'] = 'field_s_image_info_value';
+  $handler->display->display_options['fields']['field_s_image_caption']['label'] = 'imageCaption';
+  /* Field: Field collection item: Credits */
+  $handler->display->display_options['fields']['field_s_image_credits']['id'] = 'field_s_image_credits';
+  $handler->display->display_options['fields']['field_s_image_credits']['table'] = 'field_data_field_s_image_credits';
+  $handler->display->display_options['fields']['field_s_image_credits']['field'] = 'field_s_image_credits';
+  $handler->display->display_options['fields']['field_s_image_credits']['relationship'] = 'field_s_image_info_value';
+  $handler->display->display_options['fields']['field_s_image_credits']['label'] = 'imageCredits';
+  $handler->display->display_options['fields']['field_s_image_credits']['type'] = 'text_plain';
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_news_item' => 'stanford_news_item',
+  );
+  $handler->display->display_options['path'] = 'news-captioncredit-xml';
+  $export['stanford_news_export'] = $view;
+
+  return $export;
+}

--- a/modules/stanford_jsa_d8_exporter_people/README.md
+++ b/modules/stanford_jsa_d8_exporter_people/README.md
@@ -1,0 +1,3 @@
+Stanford JSA D8 People Exporter
+---
+This module provides views for exporting people data.

--- a/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.features.inc
+++ b/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.features.inc
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_people.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function stanford_jsa_d8_exporter_people_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.info
+++ b/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.info
@@ -1,0 +1,11 @@
+name = Stanford Sites Jumpstart Academic D8 People Exporter
+description = Provides views for exporting people data
+core = 7.x
+package = Stanford Sites Jumpstart Academic
+version = 7.x-6.1-dev
+hidden = TRUE
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[views_view][] = stanford_people_export
+features_exclude[dependencies][views] = views
+features_exclude[dependencies][views_data_export] = views_data_export

--- a/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.module
+++ b/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the Stanford Sites Jumpstart Academic D8 People Exporter feature.
+ */
+
+include_once 'stanford_jsa_d8_exporter_people.features.inc';

--- a/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_people/stanford_jsa_d8_exporter_people.views_default.inc
@@ -1,0 +1,389 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_people.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function stanford_jsa_d8_exporter_people_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'stanford_people_export';
+  $view->description = 'List-style page and sidebar block';
+  $view->tag = '';
+  $view->base_table = 'node';
+  $view->human_name = 'Stanford People Export';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Events';
+  $handler->display->display_options['use_more'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '0';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2] ';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  /* Field: Content: Image */
+  $handler->display->display_options['fields']['field_stanford_event_image']['id'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['table'] = 'field_data_field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['field'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['label'] = '';
+  $handler->display->display_options['fields']['field_stanford_event_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_stanford_event_image']['settings'] = array(
+    'image_style' => '',
+    'image_link' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['id'] = 'field_stanford_event_datetime_2';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['label'] = 'Date and Time (Start)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2]';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['id'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['label'] = 'Date and Time (End)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value2',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Add to Calendar */
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['id'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['table'] = 'field_data_field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['field'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['click_sort_column'] = 'url';
+  /* Field: Content: Location */
+  $handler->display->display_options['fields']['field_stanford_event_location']['id'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['table'] = 'field_data_field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['field'] = 'field_stanford_event_location';
+  /* Field: Content: Event Sponsor */
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['id'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['table'] = 'field_data_field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['field'] = 'field_stanford_event_sponsor';
+  /* Field: Content: Contact Email */
+  $handler->display->display_options['fields']['field_stanford_event_email']['id'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['table'] = 'field_data_field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['field'] = 'field_stanford_event_email';
+  /* Field: Content: Contact Phone */
+  $handler->display->display_options['fields']['field_stanford_event_phone']['id'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['table'] = 'field_data_field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['field'] = 'field_stanford_event_phone';
+  /* Field: Content: Admission */
+  $handler->display->display_options['fields']['field_stanford_event_admission']['id'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['table'] = 'field_data_field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['field'] = 'field_stanford_event_admission';
+  /* Field: Content: More Information */
+  $handler->display->display_options['fields']['field_stanford_event_url']['id'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['table'] = 'field_data_field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['field'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['click_sort_column'] = 'url';
+  /* Field: Content: Audience */
+  $handler->display->display_options['fields']['field_stanford_event_audience']['id'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['table'] = 'field_data_field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['field'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['delta_offset'] = '0';
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_stanford_event_categories']['id'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['table'] = 'field_data_field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['field'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['delta_offset'] = '0';
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_event' => 'stanford_event',
+  );
+
+  /* Display: People Data export */
+  $handler = $view->new_display('views_data_export', 'People Data export', 'views_data_export_1');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['title'] = 'People';
+  $handler->display->display_options['defaults']['query'] = FALSE;
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_xml';
+  $handler->display->display_options['style_options']['provide_file'] = 0;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['transform'] = 1;
+  $handler->display->display_options['style_options']['root_node'] = 'PeopleList';
+  $handler->display->display_options['style_options']['item_node'] = 'PeopleItem';
+  $handler->display->display_options['style_options']['no_entity_encode'] = array(
+    'field_s_person_info_links_1' => 'field_s_person_info_links_1',
+  );
+  $handler->display->display_options['style_options']['cdata_wrapper'] = array(
+    'body' => 'body',
+  );
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Content: Profile Picture (field_s_person_profile_picture:fid) */
+  $handler->display->display_options['relationships']['field_s_person_profile_picture_fid']['id'] = 'field_s_person_profile_picture_fid';
+  $handler->display->display_options['relationships']['field_s_person_profile_picture_fid']['table'] = 'field_data_field_s_person_profile_picture';
+  $handler->display->display_options['relationships']['field_s_person_profile_picture_fid']['field'] = 'field_s_person_profile_picture_fid';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid_1']['id'] = 'uuid_1';
+  $handler->display->display_options['fields']['uuid_1']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid_1']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid_1']['label'] = 'guid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'displayName';
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: First name */
+  $handler->display->display_options['fields']['field_s_person_first_name']['id'] = 'field_s_person_first_name';
+  $handler->display->display_options['fields']['field_s_person_first_name']['table'] = 'field_data_field_s_person_first_name';
+  $handler->display->display_options['fields']['field_s_person_first_name']['field'] = 'field_s_person_first_name';
+  $handler->display->display_options['fields']['field_s_person_first_name']['label'] = 'firstName';
+  $handler->display->display_options['fields']['field_s_person_first_name']['alter']['trim_whitespace'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_first_name']['type'] = 'text_plain';
+  /* Field: Content: Middle name */
+  $handler->display->display_options['fields']['field_s_person_middle_name']['id'] = 'field_s_person_middle_name';
+  $handler->display->display_options['fields']['field_s_person_middle_name']['table'] = 'field_data_field_s_person_middle_name';
+  $handler->display->display_options['fields']['field_s_person_middle_name']['field'] = 'field_s_person_middle_name';
+  $handler->display->display_options['fields']['field_s_person_middle_name']['label'] = 'middleName';
+  $handler->display->display_options['fields']['field_s_person_middle_name']['alter']['trim_whitespace'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_middle_name']['type'] = 'text_plain';
+  /* Field: Content: Last Name */
+  $handler->display->display_options['fields']['field_s_person_last_name']['id'] = 'field_s_person_last_name';
+  $handler->display->display_options['fields']['field_s_person_last_name']['table'] = 'field_data_field_s_person_last_name';
+  $handler->display->display_options['fields']['field_s_person_last_name']['field'] = 'field_s_person_last_name';
+  $handler->display->display_options['fields']['field_s_person_last_name']['label'] = 'lastName';
+  $handler->display->display_options['fields']['field_s_person_last_name']['alter']['trim_whitespace'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_last_name']['type'] = 'text_plain';
+  /* Field: Content: Affiliation */
+  $handler->display->display_options['fields']['field_s_person_affiliation']['id'] = 'field_s_person_affiliation';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['table'] = 'field_data_field_s_person_affiliation';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['field'] = 'field_s_person_affiliation';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['label'] = 'affiliation';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_person_affiliation']['separator'] = '|';
+  /* Field: Content: Degrees / Education */
+  $handler->display->display_options['fields']['field_s_person_education']['id'] = 'field_s_person_education';
+  $handler->display->display_options['fields']['field_s_person_education']['table'] = 'field_data_field_s_person_education';
+  $handler->display->display_options['fields']['field_s_person_education']['field'] = 'field_s_person_education';
+  $handler->display->display_options['fields']['field_s_person_education']['label'] = 'degreesEducation';
+  $handler->display->display_options['fields']['field_s_person_education']['type'] = 'text_plain';
+  $handler->display->display_options['fields']['field_s_person_education']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_person_education']['separator'] = '|';
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  $handler->display->display_options['fields']['body']['label'] = 'biography';
+  /* Field: Content: Title and Department */
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['id'] = 'field_s_person_faculty_title';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['table'] = 'field_data_field_s_person_faculty_title';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['field'] = 'field_s_person_faculty_title';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['label'] = 'personTitleDepartment';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['type'] = 'text_plain';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_person_faculty_title']['separator'] = '|';
+  /* Field: Content: Personal info Links */
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['id'] = 'field_s_person_info_links_1';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['table'] = 'field_data_field_s_person_info_links';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['field'] = 'field_s_person_info_links';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['label'] = 'infoLink';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['settings'] = array(
+    'custom_title' => '',
+  );
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_person_info_links_1']['separator'] = '';
+  /* Field: Content: Fields of Interest */
+  $handler->display->display_options['fields']['field_s_person_interests']['id'] = 'field_s_person_interests';
+  $handler->display->display_options['fields']['field_s_person_interests']['table'] = 'field_data_field_s_person_interests';
+  $handler->display->display_options['fields']['field_s_person_interests']['field'] = 'field_s_person_interests';
+  $handler->display->display_options['fields']['field_s_person_interests']['label'] = 'researchArea';
+  $handler->display->display_options['fields']['field_s_person_interests']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_person_interests']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_person_interests']['separator'] = '|';
+  /* Field: Content: Field of Study */
+  $handler->display->display_options['fields']['field_s_person_study']['id'] = 'field_s_person_study';
+  $handler->display->display_options['fields']['field_s_person_study']['table'] = 'field_data_field_s_person_study';
+  $handler->display->display_options['fields']['field_s_person_study']['field'] = 'field_s_person_study';
+  $handler->display->display_options['fields']['field_s_person_study']['label'] = 'fieldOfInterest';
+  $handler->display->display_options['fields']['field_s_person_study']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_s_person_study']['delta_offset'] = '0';
+  /* Field: Content: Email */
+  $handler->display->display_options['fields']['field_s_person_email']['id'] = 'field_s_person_email';
+  $handler->display->display_options['fields']['field_s_person_email']['table'] = 'field_data_field_s_person_email';
+  $handler->display->display_options['fields']['field_s_person_email']['field'] = 'field_s_person_email';
+  $handler->display->display_options['fields']['field_s_person_email']['label'] = 'email';
+  $handler->display->display_options['fields']['field_s_person_email']['type'] = 'email_plain';
+  /* Field: Content: Phone */
+  $handler->display->display_options['fields']['field_s_person_phone_display']['id'] = 'field_s_person_phone_display';
+  $handler->display->display_options['fields']['field_s_person_phone_display']['table'] = 'field_data_field_s_person_phone_display';
+  $handler->display->display_options['fields']['field_s_person_phone_display']['field'] = 'field_s_person_phone_display';
+  $handler->display->display_options['fields']['field_s_person_phone_display']['label'] = 'phone';
+  $handler->display->display_options['fields']['field_s_person_phone_display']['type'] = 'text_plain';
+  /* Field: Content: Office */
+  $handler->display->display_options['fields']['field_s_person_office_location']['id'] = 'field_s_person_office_location';
+  $handler->display->display_options['fields']['field_s_person_office_location']['table'] = 'field_data_field_s_person_office_location';
+  $handler->display->display_options['fields']['field_s_person_office_location']['field'] = 'field_s_person_office_location';
+  $handler->display->display_options['fields']['field_s_person_office_location']['label'] = 'office';
+  $handler->display->display_options['fields']['field_s_person_office_location']['type'] = 'text_plain';
+  /* Field: Content: Office Hours */
+  $handler->display->display_options['fields']['field_s_person_office_hours']['id'] = 'field_s_person_office_hours';
+  $handler->display->display_options['fields']['field_s_person_office_hours']['table'] = 'field_data_field_s_person_office_hours';
+  $handler->display->display_options['fields']['field_s_person_office_hours']['field'] = 'field_s_person_office_hours';
+  $handler->display->display_options['fields']['field_s_person_office_hours']['label'] = 'officeHours';
+  $handler->display->display_options['fields']['field_s_person_office_hours']['type'] = 'text_plain';
+  /* Field: Content: Cohort */
+  $handler->display->display_options['fields']['field_s_person_cohort']['id'] = 'field_s_person_cohort';
+  $handler->display->display_options['fields']['field_s_person_cohort']['table'] = 'field_data_field_s_person_cohort';
+  $handler->display->display_options['fields']['field_s_person_cohort']['field'] = 'field_s_person_cohort';
+  $handler->display->display_options['fields']['field_s_person_cohort']['label'] = 'cohort';
+  $handler->display->display_options['fields']['field_s_person_cohort']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_cohort']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Dissertation Title */
+  $handler->display->display_options['fields']['field_s_person_dissertatn_title']['id'] = 'field_s_person_dissertatn_title';
+  $handler->display->display_options['fields']['field_s_person_dissertatn_title']['table'] = 'field_data_field_s_person_dissertatn_title';
+  $handler->display->display_options['fields']['field_s_person_dissertatn_title']['field'] = 'field_s_person_dissertatn_title';
+  $handler->display->display_options['fields']['field_s_person_dissertatn_title']['label'] = 'dissertationTitle';
+  $handler->display->display_options['fields']['field_s_person_dissertatn_title']['type'] = 'text_plain';
+  /* Field: Content: Faculty Status */
+  $handler->display->display_options['fields']['field_s_person_faculty_type']['id'] = 'field_s_person_faculty_type';
+  $handler->display->display_options['fields']['field_s_person_faculty_type']['table'] = 'field_data_field_s_person_faculty_type';
+  $handler->display->display_options['fields']['field_s_person_faculty_type']['field'] = 'field_s_person_faculty_type';
+  $handler->display->display_options['fields']['field_s_person_faculty_type']['label'] = 'facultyType';
+  $handler->display->display_options['fields']['field_s_person_faculty_type']['type'] = 'taxonomy_term_reference_plain';
+  /* Field: Content: Graduation Year */
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['id'] = 'field_s_person_graduation_year';
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['table'] = 'field_data_field_s_person_graduation_year';
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['field'] = 'field_s_person_graduation_year';
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['label'] = 'graduationYear';
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_graduation_year']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'Y',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Staff Type */
+  $handler->display->display_options['fields']['field_s_person_staff_type']['id'] = 'field_s_person_staff_type';
+  $handler->display->display_options['fields']['field_s_person_staff_type']['table'] = 'field_data_field_s_person_staff_type';
+  $handler->display->display_options['fields']['field_s_person_staff_type']['field'] = 'field_s_person_staff_type';
+  $handler->display->display_options['fields']['field_s_person_staff_type']['label'] = 'staffType';
+  $handler->display->display_options['fields']['field_s_person_staff_type']['type'] = 'taxonomy_term_reference_plain';
+  /* Field: Content: Student Type */
+  $handler->display->display_options['fields']['field_s_person_student_type']['id'] = 'field_s_person_student_type';
+  $handler->display->display_options['fields']['field_s_person_student_type']['table'] = 'field_data_field_s_person_student_type';
+  $handler->display->display_options['fields']['field_s_person_student_type']['field'] = 'field_s_person_student_type';
+  $handler->display->display_options['fields']['field_s_person_student_type']['label'] = 'studentType';
+  $handler->display->display_options['fields']['field_s_person_student_type']['type'] = 'taxonomy_term_reference_plain';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'field_s_person_profile_picture_fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'imageUrl';
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: First name (field_s_person_first_name) */
+  $handler->display->display_options['sorts']['field_s_person_first_name_value']['id'] = 'field_s_person_first_name_value';
+  $handler->display->display_options['sorts']['field_s_person_first_name_value']['table'] = 'field_data_field_s_person_first_name';
+  $handler->display->display_options['sorts']['field_s_person_first_name_value']['field'] = 'field_s_person_first_name_value';
+  /* Sort criterion: Content: Last Name (field_s_person_last_name) */
+  $handler->display->display_options['sorts']['field_s_person_last_name_value']['id'] = 'field_s_person_last_name_value';
+  $handler->display->display_options['sorts']['field_s_person_last_name_value']['table'] = 'field_data_field_s_person_last_name';
+  $handler->display->display_options['sorts']['field_s_person_last_name_value']['field'] = 'field_s_person_last_name_value';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = '1';
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_person' => 'stanford_person',
+  );
+  $handler->display->display_options['path'] = 'people-xml';
+  $handler->display->display_options['sitename_title'] = 0;
+  $export['stanford_people_export'] = $view;
+
+  return $export;
+}

--- a/modules/stanford_jsa_d8_exporter_publications/README.md
+++ b/modules/stanford_jsa_d8_exporter_publications/README.md
@@ -1,0 +1,3 @@
+Stanford JSA D8 Publications Exporter
+---
+This module provides views for exporting publications data. 

--- a/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.features.inc
+++ b/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.features.inc
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_publications.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function stanford_jsa_d8_exporter_publications_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.info
+++ b/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.info
@@ -1,0 +1,13 @@
+name = Stanford Sites Jumpstart Academic D8 Publications Exporter
+description = Provides views for exporting publications data
+core = 7.x
+package = Stanford Sites Jumpstart Academic
+version = 7.x-6.1-dev
+hidden = TRUE
+dependencies[] = views
+dependencies[] = views_data_export
+dependencies[] = views_json
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[views_view][] = stanford_publications_export
+features_exclude[dependencies][ctools] = ctools

--- a/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.module
+++ b/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the Stanford Sites Jumpstart Academic D8 Publications Exporter feature.
+ */
+
+include_once 'stanford_jsa_d8_exporter_publications.features.inc';

--- a/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.views_default.inc
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ * @file
+ * stanford_jsa_d8_exporter_publications.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function stanford_jsa_d8_exporter_publications_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'stanford_publications_export';
+  $view->description = 'List-style page and sidebar block';
+  $view->tag = '';
+  $view->base_table = 'node';
+  $view->human_name = 'Stanford Publications Export';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'News';
+  $handler->display->display_options['use_more'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '0';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2] ';
+  $handler->display->display_options['fields']['title']['alter']['nl2br'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  /* Field: Content: Image */
+  $handler->display->display_options['fields']['field_stanford_event_image']['id'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['table'] = 'field_data_field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['field'] = 'field_stanford_event_image';
+  $handler->display->display_options['fields']['field_stanford_event_image']['label'] = '';
+  $handler->display->display_options['fields']['field_stanford_event_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_stanford_event_image']['settings'] = array(
+    'image_style' => '',
+    'image_link' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['id'] = 'field_stanford_event_datetime_2';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['label'] = 'Date and Time (Start)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2]';
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime_2']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Date and Time */
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['id'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['field'] = 'field_stanford_event_datetime';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['label'] = 'Date and Time (End)';
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_stanford_event_datetime']['settings'] = array(
+    'format_type' => 'iso_8601',
+    'fromto' => 'value2',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+  );
+  /* Field: Content: Add to Calendar */
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['id'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['table'] = 'field_data_field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['field'] = 'field_stanford_event_add_to_cal';
+  $handler->display->display_options['fields']['field_stanford_event_add_to_cal']['click_sort_column'] = 'url';
+  /* Field: Content: Location */
+  $handler->display->display_options['fields']['field_stanford_event_location']['id'] = 'field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['table'] = 'field_data_field_stanford_event_location';
+  $handler->display->display_options['fields']['field_stanford_event_location']['field'] = 'field_stanford_event_location';
+  /* Field: Content: Event Sponsor */
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['id'] = 'field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['table'] = 'field_data_field_stanford_event_sponsor';
+  $handler->display->display_options['fields']['field_stanford_event_sponsor']['field'] = 'field_stanford_event_sponsor';
+  /* Field: Content: Contact Email */
+  $handler->display->display_options['fields']['field_stanford_event_email']['id'] = 'field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['table'] = 'field_data_field_stanford_event_email';
+  $handler->display->display_options['fields']['field_stanford_event_email']['field'] = 'field_stanford_event_email';
+  /* Field: Content: Contact Phone */
+  $handler->display->display_options['fields']['field_stanford_event_phone']['id'] = 'field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['table'] = 'field_data_field_stanford_event_phone';
+  $handler->display->display_options['fields']['field_stanford_event_phone']['field'] = 'field_stanford_event_phone';
+  /* Field: Content: Admission */
+  $handler->display->display_options['fields']['field_stanford_event_admission']['id'] = 'field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['table'] = 'field_data_field_stanford_event_admission';
+  $handler->display->display_options['fields']['field_stanford_event_admission']['field'] = 'field_stanford_event_admission';
+  /* Field: Content: More Information */
+  $handler->display->display_options['fields']['field_stanford_event_url']['id'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['table'] = 'field_data_field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['field'] = 'field_stanford_event_url';
+  $handler->display->display_options['fields']['field_stanford_event_url']['click_sort_column'] = 'url';
+  /* Field: Content: Audience */
+  $handler->display->display_options['fields']['field_stanford_event_audience']['id'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['table'] = 'field_data_field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['field'] = 'field_stanford_event_audience';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_audience']['delta_offset'] = '0';
+  /* Field: Content: Categories */
+  $handler->display->display_options['fields']['field_stanford_event_categories']['id'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['table'] = 'field_data_field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['field'] = 'field_stanford_event_categories';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_stanford_event_categories']['delta_offset'] = '0';
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_event' => 'stanford_event',
+  );
+
+  /* Display: JSON */
+  $handler = $view->new_display('page', 'JSON', 'page_1');
+  $handler->display->display_options['defaults']['style_plugin'] = FALSE;
+  $handler->display->display_options['style_plugin'] = 'views_json';
+  $handler->display->display_options['style_options']['root_object'] = 'items';
+  $handler->display->display_options['style_options']['top_child_object'] = 'item';
+  $handler->display->display_options['style_options']['plaintext_output'] = 0;
+  $handler->display->display_options['style_options']['remove_newlines'] = 0;
+  $handler->display->display_options['style_options']['jsonp_prefix'] = '';
+  $handler->display->display_options['style_options']['using_views_api_mode'] = 1;
+  $handler->display->display_options['style_options']['object_arrays'] = 0;
+  $handler->display->display_options['style_options']['numeric_strings'] = 0;
+  $handler->display->display_options['style_options']['bigint_string'] = 0;
+  $handler->display->display_options['style_options']['pretty_print'] = 0;
+  $handler->display->display_options['style_options']['unescaped_slashes'] = 0;
+  $handler->display->display_options['style_options']['unescaped_unicode'] = 0;
+  $handler->display->display_options['style_options']['char_encoding'] = array();
+  $handler->display->display_options['defaults']['style_options'] = FALSE;
+  $handler->display->display_options['defaults']['row_plugin'] = FALSE;
+  $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['path'] = 'stanford-events/json';
+
+  /* Display: Publications Data export */
+  $handler = $view->new_display('views_data_export', 'Publications Data export', 'views_data_export_1');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['title'] = 'Publications';
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_xml';
+  $handler->display->display_options['style_options']['provide_file'] = 0;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['transform'] = 1;
+  $handler->display->display_options['style_options']['root_node'] = 'PublicationList';
+  $handler->display->display_options['style_options']['item_node'] = 'PublicationItem';
+  $handler->display->display_options['style_options']['no_entity_encode'] = array(
+    'field_s_pub_author' => 'field_s_pub_author',
+    'field_s_pub_document' => 'field_s_pub_document',
+  );
+  $handler->display->display_options['style_options']['cdata_wrapper'] = array(
+    'body' => 'body',
+  );
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Field: Featured Image (field_s_image_info) */
+  $handler->display->display_options['relationships']['field_s_image_info_value']['id'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['table'] = 'field_data_field_s_image_info';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['field'] = 'field_s_image_info_value';
+  $handler->display->display_options['relationships']['field_s_image_info_value']['delta'] = '-1';
+  /* Relationship: Field collection item: Image (field_s_image_image:fid) */
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['id'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['table'] = 'field_data_field_s_image_image';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['field'] = 'field_s_image_image_fid';
+  $handler->display->display_options['relationships']['field_s_image_image_fid']['relationship'] = 'field_s_image_info_value';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Node UUID */
+  $handler->display->display_options['fields']['uuid']['id'] = 'uuid';
+  $handler->display->display_options['fields']['uuid']['table'] = 'node';
+  $handler->display->display_options['fields']['uuid']['field'] = 'uuid';
+  $handler->display->display_options['fields']['uuid']['label'] = 'guid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['text'] = '[title]
+[field_stanford_event_datetime_2] ';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Author link */
+  $handler->display->display_options['fields']['field_s_person_link']['id'] = 'field_s_person_link';
+  $handler->display->display_options['fields']['field_s_person_link']['table'] = 'field_data_field_s_person_link';
+  $handler->display->display_options['fields']['field_s_person_link']['field'] = 'field_s_person_link';
+  $handler->display->display_options['fields']['field_s_person_link']['label'] = '';
+  $handler->display->display_options['fields']['field_s_person_link']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_s_person_link']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_s_person_link']['settings'] = array(
+    'bypass_access' => 0,
+    'link' => 0,
+  );
+  $handler->display->display_options['fields']['field_s_person_link']['delta_offset'] = '0';
+  /* Field: Content: Author */
+  $handler->display->display_options['fields']['field_s_pub_author']['id'] = 'field_s_pub_author';
+  $handler->display->display_options['fields']['field_s_pub_author']['table'] = 'field_data_field_s_pub_author';
+  $handler->display->display_options['fields']['field_s_pub_author']['field'] = 'field_s_pub_author';
+  $handler->display->display_options['fields']['field_s_pub_author']['label'] = 'author';
+  $handler->display->display_options['fields']['field_s_pub_author']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_s_pub_author']['alter']['text'] = '<article>[field_s_pub_author]</article>
+<article>[field_s_person_link]</article>';
+  $handler->display->display_options['fields']['field_s_pub_author']['type'] = 'text_plain';
+  $handler->display->display_options['fields']['field_s_pub_author']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_s_pub_author']['separator'] = '';
+  /* Field: Content: Body */
+  $handler->display->display_options['fields']['body']['id'] = 'body';
+  $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
+  $handler->display->display_options['fields']['body']['field'] = 'body';
+  $handler->display->display_options['fields']['body']['label'] = 'body';
+  $handler->display->display_options['fields']['body']['alter']['text'] = '[body]
+';
+  /* Field: Content: Document(s) */
+  $handler->display->display_options['fields']['field_s_pub_document']['id'] = 'field_s_pub_document';
+  $handler->display->display_options['fields']['field_s_pub_document']['table'] = 'field_data_field_s_pub_document';
+  $handler->display->display_options['fields']['field_s_pub_document']['field'] = 'field_s_pub_document';
+  $handler->display->display_options['fields']['field_s_pub_document']['label'] = 'documents';
+  $handler->display->display_options['fields']['field_s_pub_document']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_s_pub_document']['alter']['text'] = '<section>
+<article>[field_s_pub_document]</article>
+<details>[field_s_pub_document-description]</details>
+</section>';
+  $handler->display->display_options['fields']['field_s_pub_document']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_s_pub_document']['type'] = 'file_url_plain';
+  $handler->display->display_options['fields']['field_s_pub_document']['delta_offset'] = '0';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'field_s_image_image_fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'image';
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  /* Field: Content: Publisher */
+  $handler->display->display_options['fields']['field_s_pub_publisher']['id'] = 'field_s_pub_publisher';
+  $handler->display->display_options['fields']['field_s_pub_publisher']['table'] = 'field_data_field_s_pub_publisher';
+  $handler->display->display_options['fields']['field_s_pub_publisher']['field'] = 'field_s_pub_publisher';
+  $handler->display->display_options['fields']['field_s_pub_publisher']['label'] = 'publisher';
+  $handler->display->display_options['fields']['field_s_pub_publisher']['type'] = 'text_plain';
+  /* Field: Content: Publication Date */
+  $handler->display->display_options['fields']['field_s_publication_year']['id'] = 'field_s_publication_year';
+  $handler->display->display_options['fields']['field_s_publication_year']['table'] = 'field_data_field_s_publication_year';
+  $handler->display->display_options['fields']['field_s_publication_year']['field'] = 'field_s_publication_year';
+  $handler->display->display_options['fields']['field_s_publication_year']['label'] = 'publicationYear';
+  $handler->display->display_options['fields']['field_s_publication_year']['alter']['strip_tags'] = TRUE;
+  $handler->display->display_options['fields']['field_s_publication_year']['hide_empty'] = TRUE;
+  $handler->display->display_options['fields']['field_s_publication_year']['type'] = 'date_plain';
+  $handler->display->display_options['fields']['field_s_publication_year']['settings'] = array(
+    'format_type' => 'custom',
+    'custom_date_format' => 'M Y',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
+  /* Field: Content: Link */
+  $handler->display->display_options['fields']['field_s_pub_link']['id'] = 'field_s_pub_link';
+  $handler->display->display_options['fields']['field_s_pub_link']['table'] = 'field_data_field_s_pub_link';
+  $handler->display->display_options['fields']['field_s_pub_link']['field'] = 'field_s_pub_link';
+  $handler->display->display_options['fields']['field_s_pub_link']['label'] = 'publicationLinkTitle';
+  $handler->display->display_options['fields']['field_s_pub_link']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_pub_link']['type'] = 'link_title_plain';
+  $handler->display->display_options['fields']['field_s_pub_link']['settings'] = array(
+    'custom_title' => '',
+  );
+  $handler->display->display_options['fields']['field_s_pub_link']['delta_offset'] = '0';
+  /* Field: Content: Link */
+  $handler->display->display_options['fields']['field_s_pub_link_1']['id'] = 'field_s_pub_link_1';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['table'] = 'field_data_field_s_pub_link';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['field'] = 'field_s_pub_link';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['label'] = 'publicationLinkUrl';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['click_sort_column'] = 'url';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['type'] = 'link_plain';
+  $handler->display->display_options['fields']['field_s_pub_link_1']['settings'] = array(
+    'custom_title' => '',
+  );
+  $handler->display->display_options['fields']['field_s_pub_link_1']['delta_offset'] = '0';
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['field_s_pub_type']['id'] = 'field_s_pub_type';
+  $handler->display->display_options['fields']['field_s_pub_type']['table'] = 'field_data_field_s_pub_type';
+  $handler->display->display_options['fields']['field_s_pub_type']['field'] = 'field_s_pub_type';
+  $handler->display->display_options['fields']['field_s_pub_type']['label'] = 'type';
+  $handler->display->display_options['fields']['field_s_pub_type']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
+  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_publication' => 'stanford_publication',
+  );
+  $handler->display->display_options['path'] = 'publications-xml';
+  $handler->display->display_options['sitename_title'] = 0;
+  $export['stanford_publications_export'] = $view;
+
+  return $export;
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Created 4 feature modules with views exporters for specific sets of data ([see ticket](https://stanfordits.atlassian.net/browse/HSD8-925) for views links). **NOTE:** The `stanford_jsa_d8_exporter_events` feature module contained in this PR was [already a feature on the site](https://creees.stanford.edu/admin/structure/features/stanford_events_export). However, it had been overridden. I am not sure where this `stanford_events_export` feature originates from.

# Needed By (Date)
11/3

# Steps to Test
1. Pull code locally and rebuild cache
2. Open the extend/modules page and make sure all 4 new modules are unavailabe/hidden there.
3. Enable the 4 new modules through drush `drush en` -- modules are:
    -  `stanford_jsa_d8_exporter_events`
    -  `stanford_jsa_d8_exporter_news`
    -  `stanford_jsa_d8_exporter_publications`
    -  `stanford_jsa_d8_exporter_people`
4. Make sure the associated views are properly created and the paths work (I had to clear the cache after enabling module to get the page to show up). Paths are:
    -  `stanford_jsa_d8_exporter_events - `/events-xml`
    -  `stanford_jsa_d8_exporter_news - `/news-xml`
    -  `stanford_jsa_d8_exporter_publications - `/publications-xml`
    -  `stanford_jsa_d8_exporter_people - `/people-xml`

# Affected Projects or Products
H&S

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/HSD8-925

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)