### PR TITLE
HSD8-1021: Updated sort criteria for Publications and News exporters.

### DIFF
--- a/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_news/stanford_jsa_d8_exporter_news.views_default.inc
@@ -251,11 +251,11 @@ function stanford_jsa_d8_exporter_news_views_default_views() {
   $handler->display->display_options['fields']['field_s_news_categories']['type'] = 'taxonomy_term_reference_plain';
   $handler->display->display_options['fields']['field_s_news_categories']['delta_offset'] = '0';
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  /* Sort criterion: Content: Date (field_s_news_date) */
+  $handler->display->display_options['sorts']['field_s_news_date_value']['id'] = 'field_s_news_date_value';
+  $handler->display->display_options['sorts']['field_s_news_date_value']['table'] = 'field_data_field_s_news_date';
+  $handler->display->display_options['sorts']['field_s_news_date_value']['field'] = 'field_s_news_date_value';
+  $handler->display->display_options['sorts']['field_s_news_date_value']['order'] = 'DESC';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */

--- a/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.views_default.inc
+++ b/modules/stanford_jsa_d8_exporter_publications/stanford_jsa_d8_exporter_publications.views_default.inc
@@ -328,11 +328,11 @@ function stanford_jsa_d8_exporter_publications_views_default_views() {
   $handler->display->display_options['fields']['field_s_pub_type']['label'] = 'type';
   $handler->display->display_options['fields']['field_s_pub_type']['type'] = 'taxonomy_term_reference_plain';
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Date and Time -  start date (field_stanford_event_datetime) */
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['id'] = 'field_stanford_event_datetime_value';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['table'] = 'field_data_field_stanford_event_datetime';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['field'] = 'field_stanford_event_datetime_value';
-  $handler->display->display_options['sorts']['field_stanford_event_datetime_value']['order'] = 'DESC';
+  /* Sort criterion: Content: Date added (field_s_publication_year) */
+  $handler->display->display_options['sorts']['field_s_publication_year_value']['id'] = 'field_s_publication_year_value';
+  $handler->display->display_options['sorts']['field_s_publication_year_value']['table'] = 'field_data_field_s_publication_year';
+  $handler->display->display_options['sorts']['field_s_publication_year_value']['field'] = 'field_s_publication_year_value';
+  $handler->display->display_options['sorts']['field_s_publication_year_value']['order'] = 'DESC';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updated sort criteria for exporters

# Needed By (Date)
- 7/02

# Urgency
- Medium/Low

# Steps to Test
1. Setup locally
2. Enable `stanford_jsa_d8_exporter_publications` and `stanford_jsa_d8_exporter_news` modules
3. Edit/review both views and verify sort criteria change:
  -  `/admin/structure/views/view/stanford_news_export/edit/views_data_export_1`
  - `/admin/structure/views/view/stanford_publications_export/edit/views_data_export_1`

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/HSD8-1021

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
